### PR TITLE
Configure IConnectionMultiplexer Through Dependecy Injection

### DIFF
--- a/src/HybridRedisCache.Test/HybridCacheTests.cs
+++ b/src/HybridRedisCache.Test/HybridCacheTests.cs
@@ -15,7 +15,7 @@ public class HybridCacheTests : IDisposable
     private HybridCache _cache;
     private HybridCachingOptions _options;
     private string uniqueKey => "test_Key_" + Guid.NewGuid().ToString("N");
-    protected HybridCache Cache => _cache ?? (_cache = new HybridCache(_options, _loggerFactory));
+    protected HybridCache Cache => _cache ?? (_cache = new HybridCache(_options, loggerFactory:_loggerFactory));
 
     public HybridCacheTests()
     {
@@ -289,9 +289,14 @@ public class HybridCacheTests : IDisposable
         var value1 = "myValue1";
         var value2 = "newValue2";
 
-        // create two instances of HybridCache that share the same Redis cache
+        // create first instance of HybridCache that share the same Redis cache
         var instance1 = new HybridCache(_options);
-        var instance2 = new HybridCache(_options);
+
+        //Because we want to simulate two different applications, their options must be two different object references as well
+        var options2 = _options.DeepCopyCachingOptions();
+
+        // create second instance of HybridCache that share the same Redis cache
+        var instance2 = new HybridCache(options2);
 
         // set a value in the shared cache using instance1
         await instance1.SetAsync(key, value1, fireAndForget: false);

--- a/src/HybridRedisCache/HybridCacheServiceCollectionExtensions.cs
+++ b/src/HybridRedisCache/HybridCacheServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
 
 namespace HybridRedisCache;
 
@@ -23,8 +24,15 @@ public static class HybridCacheServiceCollectionExtensions
         var options = new HybridCachingOptions();
         setupAction(options);
 
+
+        var redisConnection =
+            ConnectionMultiplexer.Connect(options.ConvertHybridCacheOptionsToRedisOptions());
+
+        services.AddSingleton<IConnectionMultiplexer>(redisConnection);
+
+
         services.AddSingleton(options);
-        services.Add(ServiceDescriptor.Singleton<IHybridCache, HybridCache>());
+        services.AddSingleton<IHybridCache, HybridCache>();
 
         return services;
     }

--- a/src/HybridRedisCache/HybridCachingOptions.cs
+++ b/src/HybridRedisCache/HybridCachingOptions.cs
@@ -1,4 +1,9 @@
-﻿namespace HybridRedisCache;
+﻿
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("HybridRedisCache.Test")]
+namespace HybridRedisCache;
+
 
 public class HybridCachingOptions
 {
@@ -80,5 +85,10 @@ public class HybridCachingOptions
     /// Set the connection keep alive value in seconds. Default is 60s
     /// </summary>
     public int KeepAlive { get; set; } = 60;
+
+    /// <summary>
+    /// an id specified for application using hybrid cache. 
+    /// </summary>
+    internal string InstanceId { get; }= Guid.NewGuid().ToString("N");
 
 }

--- a/src/HybridRedisCache/InternalExtensions.cs
+++ b/src/HybridRedisCache/InternalExtensions.cs
@@ -1,0 +1,48 @@
+﻿using StackExchange.Redis;
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("HybridRedisCache.Test")]
+namespace HybridRedisCache;
+
+internal static class InternalExtensions
+{
+    /// <summary>
+    /// Extension method for converting hybrid cache options to StackExchange configuration options
+    /// </summary>
+    /// <param name="option"></param>
+    /// <returns></returns>
+    public static ConfigurationOptions ConvertHybridCacheOptionsToRedisOptions(this HybridCachingOptions option)
+    {
+        var redisConfig = ConfigurationOptions.Parse(option.RedisConnectString, true);
+        redisConfig.AbortOnConnectFail = option.AbortOnConnectFail;
+        redisConfig.ConnectRetry = option.ConnectRetry;
+        redisConfig.ClientName = option.InstancesSharedName + ":" + option.InstanceId;
+        redisConfig.AsyncTimeout = option.AsyncTimeout;
+        redisConfig.SyncTimeout = option.SyncTimeout;
+        redisConfig.ConnectTimeout = option.ConnectionTimeout;
+        redisConfig.KeepAlive = option.KeepAlive;
+        redisConfig.AllowAdmin = option.AllowAdmin;
+
+        return redisConfig;
+    }
+
+    public static HybridCachingOptions DeepCopyCachingOptions(this HybridCachingOptions options)
+    {
+        return new HybridCachingOptions()
+        {
+            AbortOnConnectFail = options.AbortOnConnectFail,
+            AllowAdmin = options.AllowAdmin,
+            AsyncTimeout = options.AsyncTimeout,
+            ConnectRetry = options.ConnectRetry,
+            ConnectionTimeout = options.ConnectionTimeout,
+            DefaultDistributedExpirationTime = options.DefaultDistributedExpirationTime,
+            DefaultLocalExpirationTime = options.DefaultLocalExpirationTime,
+            EnableLogging = options.EnableLogging,
+            FlushLocalCacheOnBusReconnection = options.FlushLocalCacheOnBusReconnection,
+            InstancesSharedName = options.InstancesSharedName,
+            KeepAlive = options.KeepAlive,
+            RedisConnectString = options.RedisConnectString,
+            SyncTimeout = options.SyncTimeout,
+            ThrowIfDistributedCacheError = options.ThrowIfDistributedCacheError
+        };
+    }
+}


### PR DESCRIPTION
Added a feature that when HybridCache is configured through dependency injection , an instance of IConnectionMultiplexer be also configured as singleton and be available for HybridCache class